### PR TITLE
Add OpenRouter provider support with priority handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,10 +7,15 @@ Note: You can set `OLLAMA_API_BASE_URL` to your Ollama API URL if you are using 
       Then you can set any model string in the `args.llm_backend` flag or the `Custom LLM Backend (For Ollama)` field in the UI.
 
 Read more about Ollama: https://ollama.com/blog/openai-compatibility
+
+For OpenRouter:
+      Set your OpenRouter API key in the environment variable `OPENROUTER_API_KEY`.
+      Use model names with 'openrouter/' prefix to automatically use the OpenRouter provider.
 """
 GOOGLE_GENERATIVE_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/"
 DEEPSEEK_API_BASE_URL = "https://api.deepseek.com/v1"
 OLLAMA_API_BASE_URL = "http://localhost:11434/v1/"
+OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1"
 
 """
 TASK_NOTE_LLM Configuration Guide

--- a/provider.py
+++ b/provider.py
@@ -117,3 +117,47 @@ class AnthropicProvider:
                 temperature=temperature,
             )
         return message.content[0].text
+
+
+class OpenRouterProvider:
+    @staticmethod
+    def get_response(
+        api_key: str,
+        model_name: str,
+        user_prompt: str,
+        system_prompt: str,
+        temperature: float = None,
+        base_url: str | None = None,
+    ) -> str:
+        # Remove 'openrouter/' prefix if present for the actual API call
+        actual_model_name = model_name
+        if model_name.startswith("openrouter/"):
+            actual_model_name = model_name[len("openrouter/"):]
+        
+        client_config = {
+            "api_key": api_key,
+        }
+        
+        if base_url:
+            client_config["base_url"] = base_url
+            
+        client = OpenAI(**client_config)
+        
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt}
+        ]
+        
+        if temperature is None:
+            completion = client.chat.completions.create(
+                model=actual_model_name,
+                messages=messages,
+            )
+        else:
+            completion = client.chat.completions.create(
+                model=actual_model_name,
+                messages=messages,
+                temperature=temperature,
+            )
+            
+        return completion.choices[0].message.content


### PR DESCRIPTION
## Description
This PR adds explicit support for the OpenRouter provider in the codebase and modifies it to prioritize using the OpenRouter provider when a model name contains "openrouter/".

## Changes
- Added `OpenRouterProvider` class to `provider.py`
- Added OpenRouter API base URL to `config.py`
- Modified `inference.py` to prioritize OpenRouter when model name contains "openrouter/"
- Added OpenRouter to cost estimation maps with default values
- Added documentation about how to use OpenRouter

## Usage
To use OpenRouter:
1. Set your OpenRouter API key in the environment variable `OPENROUTER_API_KEY`
2. Use model names with "openrouter/" prefix (e.g., "openrouter/anthropic/claude-3-opus") to automatically use the OpenRouter provider

## Testing
Basic import testing has been performed to ensure the code compiles correctly.